### PR TITLE
remove dependency on left-pad

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@markusylisiurunen/git-stats",
-  "version": "0.1.1-alpha",
+  "version": "0.2.0-alpha",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -576,11 +576,6 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
       "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
-    },
-    "left-pad": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/left-pad/-/left-pad-1.3.0.tgz",
-      "integrity": "sha512-XI5MPzVNApjAyhQzphX8BkmKsKUxD4LdyK24iZeQGinBN9yTQT3bFlCBy/aVx2HrNcqQGsdot8ghrjyrvMCoEA=="
     },
     "map-cache": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "@markusylisiurunen/md-table": "^0.2.0-alpha",
     "anymatch": "^2.0.0",
-    "left-pad": "^1.3.0",
     "minimist": "^1.2.0"
   },
   "devDependencies": {

--- a/src/commands/author.js
+++ b/src/commands/author.js
@@ -2,7 +2,6 @@
  * @overview Print statistics by author.
  */
 
-const pad = require('left-pad');
 const { sortByColumn, printSection } = require('../helpers');
 
 /**
@@ -34,11 +33,11 @@ module.exports = (commits, args) => {
 
   const data = Object.entries(byAuthor)
     .map(([author, { inserted, deleted, total }]) => {
-      let shareOfInserted = !totalInserted ? 0 : inserted / totalInserted * 100;
-      let shareOfDeleted = !totalDeleted ? 0 : deleted / totalDeleted * 100;
+      let shareOfInserted = (!totalInserted ? 0 : inserted / totalInserted * 100).toFixed(1);
+      let shareOfDeleted = (!totalDeleted ? 0 : deleted / totalDeleted * 100).toFixed(1);
 
-      shareOfInserted = pad(shareOfInserted.toFixed(1), 5);
-      shareOfDeleted = pad(shareOfDeleted.toFixed(1), 5);
+      shareOfInserted = String(shareOfInserted).padStart(5);
+      shareOfDeleted = String(shareOfDeleted).padStart(5);
 
       return [
         author,

--- a/src/commands/files.js
+++ b/src/commands/files.js
@@ -2,7 +2,6 @@
  * @overview Print statistics by file.
  */
 
-const pad = require('left-pad');
 const { sortByColumn, printSection } = require('../helpers');
 
 /**
@@ -56,11 +55,11 @@ module.exports = (commits, args) => {
         const { inserted: sInserted, deleted: sDeleted } = stats;
         const { inserted: tInserted, deleted: tDeleted } = entry;
 
-        let shareOfInserted = !sInserted ? 0 : sInserted / tInserted * 100;
-        let shareOfDeleted = !sDeleted ? 0 : sDeleted / tDeleted * 100;
+        let shareOfInserted = (!sInserted ? 0 : sInserted / tInserted * 100).toFixed(1);
+        let shareOfDeleted = (!sDeleted ? 0 : sDeleted / tDeleted * 100).toFixed(1);
 
-        shareOfInserted = pad(shareOfInserted.toFixed(1), 5);
-        shareOfDeleted = pad(shareOfDeleted.toFixed(1), 5);
+        shareOfInserted = String(shareOfInserted).padStart(5);
+        shareOfDeleted = String(shareOfDeleted).padStart(5);
 
         return `${shareOfInserted} %  ${shareOfDeleted} %`;
       });


### PR DESCRIPTION
Uses `String.prototype.padStart` (available in Node >=8.0.0)